### PR TITLE
Remove need for extra docker environment files in acas #3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,9 @@ RUN cp ./lib/libbingo-postgres.so /usr/lib/postgresql/13/lib && \
 
 COPY src/* /docker-entrypoint-initdb.d/
 
-ENV ACAS=true
 ENV ACAS_SCHEMA=acas
 ENV ACAS_USERNAME=acas
 ENV ACAS_PASSWORD=acas
-ENV ACAS_FLYWAY_LOCATION=com.labsynch.labseer.db.migration.postgres,db/migration/postgres,db/migration/indigo/postgres
 ENV DB_NAME=acas
 ENV DB_USER=acas_admin
 ENV DB_PASSWORD=acas_admin

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,14 @@ RUN cp ./lib/libbingo-postgres.so /usr/lib/postgresql/13/lib && \
 
 COPY src/* /docker-entrypoint-initdb.d/
 
+ENV ACAS=true
+ENV ACAS_SCHEMA=acas
+ENV ACAS_USERNAME=acas
+ENV ACAS_PASSWORD=acas
+ENV ACAS_FLYWAY_LOCATION=com.labsynch.labseer.db.migration.postgres,db/migration/postgres,db/migration/indigo/postgres
+ENV DB_NAME=acas
+ENV DB_USER=acas_admin
+ENV DB_PASSWORD=acas_admin
+ENV POSTGRES_PASSWORD=postgres
+
 CMD ["postgres", "-c", "log_connections=on", "-c", "log_disconnections=on"]

--- a/src/initdbs.sh
+++ b/src/initdbs.sh
@@ -100,43 +100,38 @@ create_or_alter_user $DB_USER $DB_PASSWORD $OP
 grant "ALL PRIVILEGES ON DATABASE $DB_NAME to $DB_USER"
 echo
 
-echo "******CHECKING IF ACAS NEEDED******"
-ACAS=$ACAS
-ACAS=${ACAS:-false}
-if [[ $ACAS == "true" ]]; then
+echo "******CHECKING IF $ACAS_USERNAME USER EXISTS******"
+USEREXISTS=$(user_exists $ACAS_USERNAME)
+if [[ $USEREXISTS == "1" ]]; then
 	echo true
-	echo "******CHECKING IF $ACAS_USERNAME USER EXISTS******"
-	USEREXISTS=$(user_exists $ACAS_USERNAME)
-	if [[ $USEREXISTS == "1" ]]; then
-		echo true
-		echo "******$ACAS_USERNAME USER ALREADY EXISTS******"
-		OP=ALTER
-	else
-		echo false
-		OP=CREATE
-	fi
-	echo "******${OP}ing $ACAS_USERNAME USER******"
-	create_or_alter_user $ACAS_USERNAME $ACAS_PASSWORD $OP
-	echo
-
-	echo "******CHECKING IF $ACAS_SCHEMA SCHEMA EXISTS******"
-	SCHEMAEXISTS=$(schema_exists $ACAS_SCHEMA)
-	if [[ $SCHEMAEXISTS == "1" ]]; then
-		echo true
-		echo "******$ACAS_SCHEMA SCHEMA ALREADY EXISTS******"
-	else
-		echo false
-		echo "******CREATING $ACAS_SCHEMA schema******"
-		create_schema $ACAS_SCHEMA $ACAS_USERNAME
-		echo
-	fi
-	echo "******CREATING EXTENSIONS rdkit and btree_gist******"
-	run "CREATE EXTENSION btree_gist"
-
-	run "$(cat /bingo-build/bingo_install.sql)"
-	grant "USAGE ON SCHEMA bingo TO $ACAS_USERNAME"
-	grant "SELECT ON ALL TABLES IN SCHEMA bingo TO $ACAS_USERNAME"
-	grant "EXECUTE ON ALL FUNCTIONS IN SCHEMA bingo TO $ACAS_USERNAME"
-	grant "USAGE ON SCHEMA bingo TO $ACAS_USERNAME"
-	alter "ROLE $ACAS_USERNAME SET search_path = public, $ACAS_SCHEMA, bingo"
+	echo "******$ACAS_USERNAME USER ALREADY EXISTS******"
+	OP=ALTER
+else
+	echo false
+	OP=CREATE
 fi
+echo "******${OP}ing $ACAS_USERNAME USER******"
+create_or_alter_user $ACAS_USERNAME $ACAS_PASSWORD $OP
+echo
+
+echo "******CHECKING IF $ACAS_SCHEMA SCHEMA EXISTS******"
+SCHEMAEXISTS=$(schema_exists $ACAS_SCHEMA)
+if [[ $SCHEMAEXISTS == "1" ]]; then
+	echo true
+	echo "******$ACAS_SCHEMA SCHEMA ALREADY EXISTS******"
+else
+	echo false
+	echo "******CREATING $ACAS_SCHEMA schema******"
+	create_schema $ACAS_SCHEMA $ACAS_USERNAME
+	echo
+fi
+echo "******CREATING EXTENSIONS rdkit and btree_gist******"
+run "CREATE EXTENSION btree_gist"
+
+run "$(cat /bingo-build/bingo_install.sql)"
+grant "USAGE ON SCHEMA bingo TO $ACAS_USERNAME"
+grant "SELECT ON ALL TABLES IN SCHEMA bingo TO $ACAS_USERNAME"
+grant "EXECUTE ON ALL FUNCTIONS IN SCHEMA bingo TO $ACAS_USERNAME"
+grant "USAGE ON SCHEMA bingo TO $ACAS_USERNAME"
+alter "ROLE $ACAS_USERNAME SET search_path = public, $ACAS_SCHEMA, bingo"
+


### PR DESCRIPTION
## Description
 - Added default environment variables
 - Removed a boolean environment variables "ACAS" which configured whether we wanted acas or not, we always do so removing.

## Related Issue
Fixes #3 

## How Has This Been Tested?
I build the docker image and added it to my docker-compose.yml in base acas
I deleted on config/docker/**.env files
I ran on acasclient tests and they passed

I will spin out a ticket to remove the .env files from acas base after this is merged and pushed.
I also plan on just pushing a new version of mcneilco/acas-postgres:1.13.7 since this should all be backwards compatable.