### PR TITLE
ACAS-674: Add pg_trgm extension in non-k8s postgres database.

### DIFF
--- a/src/initdbs.sh
+++ b/src/initdbs.sh
@@ -125,8 +125,9 @@ else
 	create_schema $ACAS_SCHEMA $ACAS_USERNAME
 	echo
 fi
-echo "******CREATING EXTENSIONS rdkit and btree_gist******"
+echo "******CREATING EXTENSIONS btree_gist and pg_trgm******"
 run "CREATE EXTENSION btree_gist"
+run "CREATE EXTENSION IF NOT EXISTS pg_trgm"
 
 run "$(cat /bingo-build/bingo_install.sql)"
 grant "USAGE ON SCHEMA bingo TO $ACAS_USERNAME"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
https://github.com/mcneilco/acas-roo-server/pull/445 is adding ordering of compound search results based on trigram similarity match. We need to create a new image with `pg_trgm` extension added.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-674](https://jira.schrodinger.com/browse/ACAS-674)

## How Has This Been Tested?
<!--- Describe how this has been tested -->
I created a local build and updated acas to use this database image. I verified compound search shows results without any errors and without manually having to create the extension.

## Note:
I had trouble with `dnf config-manager` when building the image, but @brianbolt didn't face any issues. I am still not sure why it's happening and so I also installed `config-manager` to build the image but haven't added those changes here, since Brian will create a new image and manually push it. I tested the `arm/64` built image.